### PR TITLE
fix(ci): Allow bench action to write to gitignored dir

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add docs/benches.jsonl
+          git add -f docs/benches.jsonl
           if git diff --staged --quiet; then
             echo "No changes to benchmark results"
           else


### PR DESCRIPTION
Use `git add -f` to force-add `docs/benches.jsonl` since `/docs` is in .gitignore.